### PR TITLE
An incorrect example of sendPayment with error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,14 @@ try {
   console.warn("Prompt closed");
 }
 await nwc.enable();
-const response = await nwc.sendPayment(invoice);
-// ! always check the response 
-if (response.preimage) { 
-  console.info("payment successful");
-} else {
-  console.error(response);
+let response;
+try {
+  response = await nwc.sendPayment(invoice);
+  // if success then the response.preimage will be only
+  console.info(`payment successful, the preimage is ${response.preimage}`);
+}
+catch (e) {
+  console.error(e.error || e);
 }
 ```
 


### PR DESCRIPTION
Judging by the code, the sendPayment function creates a promise where, in case of an error, it will reject. That is, an exception will be thrown with an error string but not as in the example - an error is returned as a response.

Moreover, in the code, an reject returns an object in some places, in others - a string.