### PR TITLE
feat: add user_agent to options

### DIFF
--- a/src/OAuth2User.ts
+++ b/src/OAuth2User.ts
@@ -19,6 +19,7 @@ export interface OAuth2UserOptions {
   callback: string;
   scopes: OAuth2Scopes[];
   request_options?: Partial<RequestOptions>;
+  user_agent: string;
   token?: Token;
 }
 
@@ -48,7 +49,7 @@ export class OAuth2User implements OAuthClient {
    */
   async refreshAccessToken(): Promise<{ token: Token }> {
     const refresh_token = this.token?.refresh_token;
-    const { client_id, client_secret, request_options } = this.options;
+    const { client_id, client_secret, request_options, user_agent } = this.options;
     if (!client_id) {
       throw new Error("client_id is required");
     }
@@ -63,6 +64,7 @@ export class OAuth2User implements OAuthClient {
         grant_type: "refresh_token",
         refresh_token,
       },
+      user_agent,
       method: "POST",
       headers: {
         ...request_options?.headers,
@@ -91,7 +93,7 @@ export class OAuth2User implements OAuthClient {
    * Request an access token
    */
   async requestAccessToken(code?: string): Promise<{ token: Token }> {
-    const { client_id, client_secret, callback, request_options } =
+    const { client_id, client_secret, callback, request_options, user_agent } =
       this.options;
     const code_verifier = this.code_verifier;
     if (!client_id) {
@@ -111,6 +113,7 @@ export class OAuth2User implements OAuthClient {
       ...request_options,
       endpoint: `/oauth/token`,
       params,
+      user_agent,
       method: "POST",
       headers: {
         ...request_options?.headers,

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,10 +23,7 @@ export class Client {
     this.auth = typeof auth === "string" ? new OAuth2Bearer(auth) : auth;
     this.defaultRequestOptions = {
       ...requestOptions,
-      headers: {
-        "User-Agent": "alby-js-api",
-        ...requestOptions?.headers,
-      },
+      user_agent: requestOptions?.user_agent ?? "alby-js-api"
     };
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,7 +23,7 @@ export class Client {
     this.auth = typeof auth === "string" ? new OAuth2Bearer(auth) : auth;
     this.defaultRequestOptions = {
       ...requestOptions,
-      user_agent: requestOptions?.user_agent ?? "alby-js-api"
+      user_agent: requestOptions?.user_agent
     };
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -80,12 +80,12 @@ export async function request({
         ...(isPost
           ? { "Content-Type": "application/json; charset=utf-8" }
           : undefined),
+        ...authHeader,
+        ...headers,
         ...{
           "User-Agent": user_agent ?? "alby-js-api",
           "X-User-Agent": user_agent ?? "alby-js-api"
         },
-        ...authHeader,
-        ...headers,
       },
       method,
       body: isPost ? JSON.stringify(request_body) : undefined,

--- a/src/request.ts
+++ b/src/request.ts
@@ -80,9 +80,10 @@ export async function request({
         ...(isPost
           ? { "Content-Type": "application/json; charset=utf-8" }
           : undefined),
-        ...(user_agent
-          ? { "User-Agent": user_agent, "X-User-Agent": user_agent }
-          : undefined),
+        ...{
+          "User-Agent": user_agent ?? "alby-js-api",
+          "X-User-Agent": user_agent ?? "alby-js-api"
+        },
         ...authHeader,
         ...headers,
       },

--- a/src/request.ts
+++ b/src/request.ts
@@ -10,6 +10,7 @@ export interface RequestOptions extends Omit<RequestInit, "body"> {
   auth?: AuthClient;
   endpoint: string;
   params?: Record<string, any>;
+  user_agent?: string;
   request_body?: Record<string, any>;
   method?: string;
   max_retries?: number;
@@ -62,6 +63,7 @@ export async function request({
   method,
   max_retries,
   base_url = BASE_URL,
+  user_agent,
   headers,
   ...options
 }: RequestOptions): Promise<Response> {
@@ -77,6 +79,9 @@ export async function request({
       headers: {
         ...(isPost
           ? { "Content-Type": "application/json; charset=utf-8" }
+          : undefined),
+        ...(user_agent
+          ? { "User-Agent": user_agent }
           : undefined),
         ...authHeader,
         ...headers,

--- a/src/request.ts
+++ b/src/request.ts
@@ -81,7 +81,7 @@ export async function request({
           ? { "Content-Type": "application/json; charset=utf-8" }
           : undefined),
         ...(user_agent
-          ? { "User-Agent": user_agent }
+          ? { "User-Agent": user_agent, "X-User-Agent": user_agent }
           : undefined),
         ...authHeader,
         ...headers,


### PR DESCRIPTION
Fixes #16 
Changes the rest function to have user-agent as param, also supports passing user_agent header as usual

(If both are passed, the one passed as the header will be considered)