### PR TITLE
feat: setup outDir Directory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "target": "es2020",
     "rootDir": "./src",
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "outDir": "./dist"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Cannot write file '/home/pavan/Desktop/codebases/getAlby/alby-js-sdk-master/alby-js-sdk/src/window.js' because it would overwrite input file.

![image](https://github.com/getAlby/alby-js-sdk/assets/55848322/268e12d6-5f4f-49be-b849-af73e9f37fb7)
